### PR TITLE
Update skills from MNCH session feedback

### DIFF
--- a/internal/feedback-mnch-session.md
+++ b/internal/feedback-mnch-session.md
@@ -1,0 +1,88 @@
+# Feedback: MNCH Implementation Session (2026-03-14)
+
+Lessons learned from implementing stillbirth/miscarriage/NND classification and congenital framework in starsim. These should inform skill updates.
+
+## Mistakes Made
+
+### 1. `modules=` vs `custom=` for non-standard modules (starsim-dev-sim, starsim-dev-demographics)
+
+**What happened**: Used `modules=ss.FetalHealth()` in sim construction. Since v3.2.0, non-standard modules go via `custom=`.
+
+**Fix for skills**: The `starsim-dev-sim` skill should document that `custom=` is the correct kwarg for modules that don't fit standard types (diseases, interventions, demographics, networks, connectors, analyzers). The `modules=` argument still works but auto-relocates.
+
+### 2. Module instances cannot be shared across sims (starsim-dev-sim, starsim-style-tests)
+
+**What happened**: Tried `demog = [ss.Pregnancy(...), ss.Deaths(...)]` and passed the same list to three different sims. The second and third sims failed because starsim modules are mutated during `sim.init()` — they get bound to a specific sim, their states get initialized, etc.
+
+**Fix for skills**: Add an anti-pattern to `starsim-dev-sim`:
+```python
+# WRONG — modules are mutated during init, can't be reused
+demog = [ss.Pregnancy(), ss.Deaths()]
+sim1 = ss.Sim(demographics=demog).run()
+sim2 = ss.Sim(demographics=demog).run()  # Fails or gives wrong results
+
+# RIGHT — use a factory function
+def make_demog():
+    return [ss.Pregnancy(), ss.Deaths()]
+sim1 = ss.Sim(demographics=make_demog()).run()
+sim2 = ss.Sim(demographics=make_demog()).run()
+```
+
+Also add to `starsim-style-tests` as a common test pattern (multiple sims need fresh module instances).
+
+### 3. Misleading naming (starsim-style-python)
+
+**What happened**: Named a connector `fetal_tx` when it actually applies disease *damage* to fetal health. "tx" implies treatment. Should have been `fetal_infection` (the thing that connects a disease to fetal damage).
+
+**Lesson**: The style guide says names should be "short but memorable." Memorable includes *not being misleading*. A connector that orchestrates damage from infection should reference "infection" not "treatment" in its name.
+
+### 4. Manual time conversion instead of starsim API (starsim-dev-time)
+
+**What happened**: Used `self.sim.people.age[uids] * 365.25` to convert years to days. Should have used `ss.years(self.sim.people.age[uids]).days`.
+
+**Fix for skills**: Add to `starsim-dev-time`:
+```python
+# WRONG — manual conversion, fragile
+age_days = sim.people.age[uids] * 365.25
+
+# RIGHT — starsim time API, works with arrays
+age_days = ss.years(sim.people.age[uids]).days
+```
+
+### 5. Stochastic comparison without tolerance (starsim-style-tests)
+
+**What happened**: Compared birth weights across different sims with `assert bw_treated > bw_disease`. With different random streams (fresh module instances per sim), this can fail by small margins. Fixed with `assert bw_treated > bw_disease * (1 - rtol)` where `rtol = 0.05`.
+
+**Note**: The test style guide already mentions generous tolerances, but could emphasize that *directional* comparisons (not just equality) need tolerance too.
+
+### 6. `.values` on starsim arrays (starsim-dev-indexing)
+
+**What happened**: Used `fh.birth_weight[born].values` in plotting code. Starsim `Arr` objects don't have a `.values` attribute like pandas. Use `np.asarray(arr)` to extract raw numpy arrays.
+
+**Fix for skills**: Add to `starsim-dev-indexing`:
+```python
+# WRONG — starsim arrays are not pandas
+data = arr[mask].values
+
+# RIGHT — use np.asarray for raw numpy
+data = np.asarray(arr[mask])
+```
+
+### 7. Removing imports still needed by remaining code (general)
+
+**What happened**: When moving `test_fetal_health` out of `test_demographics.py`, also removed `import matplotlib.pyplot as plt` — but `test_nigeria` still uses `plt`. General lesson: when refactoring, check that remaining code doesn't depend on things being removed.
+
+### 8. Lambda vs named function for readability (starsim-style-python)
+
+**What happened**: Used `demog = lambda: [ss.Pregnancy(...), ss.Deaths(...)]` which was confusing to the user. A named `def demog()` is clearer and more debuggable.
+
+**Lesson**: Starsim style prefers clarity. Lambdas are fine for simple expressions but not for multi-line module construction.
+
+## Skills That Need Updates
+
+1. **starsim-dev-sim**: Document `custom=` kwarg; add module-sharing anti-pattern
+2. **starsim-dev-time**: Add array time conversion pattern (`ss.years(array).days`)
+3. **starsim-dev-indexing**: Add `np.asarray()` pattern for extracting raw arrays
+4. **starsim-dev-demographics**: Document pregnancy loss classification, NND detection, FetalHealth, congenital framework
+5. **starsim-dev-diseases**: Document generic congenital framework (`set_congenital`, `fire_congenital_outcomes`, `birth_outcome_keys`, `birth_outcomes`)
+6. **starsim-style-tests**: Add module factory pattern for multi-sim tests; note directional comparison tolerances

--- a/internal/feedback-mnch-session.md
+++ b/internal/feedback-mnch-session.md
@@ -10,25 +10,11 @@ Lessons learned from implementing stillbirth/miscarriage/NND classification and 
 
 **Fix for skills**: The `starsim-dev-sim` skill should document that `custom=` is the correct kwarg for modules that don't fit standard types (diseases, interventions, demographics, networks, connectors, analyzers). The `modules=` argument still works but auto-relocates.
 
-### 2. Module instances cannot be shared across sims (starsim-dev-sim, starsim-style-tests)
+### 2. ~~Module instances cannot be shared across sims~~ (starsim-dev-sim, starsim-style-tests)
 
-**What happened**: Tried `demog = [ss.Pregnancy(...), ss.Deaths(...)]` and passed the same list to three different sims. The second and third sims failed because starsim modules are mutated during `sim.init()` — they get bound to a specific sim, their states get initialized, etc.
+**What happened**: Tried `demog = [ss.Pregnancy(...), ss.Deaths(...)]` and passed the same list to three different sims. Something else went wrong, but we initially blamed module sharing.
 
-**Fix for skills**: Add an anti-pattern to `starsim-dev-sim`:
-```python
-# WRONG — modules are mutated during init, can't be reused
-demog = [ss.Pregnancy(), ss.Deaths()]
-sim1 = ss.Sim(demographics=demog).run()
-sim2 = ss.Sim(demographics=demog).run()  # Fails or gives wrong results
-
-# RIGHT — use a factory function
-def make_demog():
-    return [ss.Pregnancy(), ss.Deaths()]
-sim1 = ss.Sim(demographics=make_demog()).run()
-sim2 = ss.Sim(demographics=make_demog()).run()
-```
-
-Also add to `starsim-style-tests` as a common test pattern (multiple sims need fresh module instances).
+**Correction**: This is actually fine — `copy_inputs=True` by default, so starsim deep-copies module instances when initializing. No skill update needed.
 
 ### 3. Misleading naming (starsim-style-python)
 
@@ -57,15 +43,15 @@ age_days = ss.years(sim.people.age[uids]).days
 
 ### 6. `.values` on starsim arrays (starsim-dev-indexing)
 
-**What happened**: Used `fh.birth_weight[born].values` in plotting code. Starsim `Arr` objects don't have a `.values` attribute like pandas. Use `np.asarray(arr)` to extract raw numpy arrays.
+**What happened**: Used `fh.birth_weight[born].values` in plotting code. `ss.Arr` objects *do* have `.values` (like pandas), but indexing an `Arr` with UIDs returns a plain NumPy array (which doesn't have `.values`).
 
 **Fix for skills**: Add to `starsim-dev-indexing`:
 ```python
-# WRONG — starsim arrays are not pandas
-data = arr[mask].values
+# WRONG — indexing with UIDs already returns a plain numpy array
+data = arr[uids].values  # AttributeError: numpy array has no .values
 
-# RIGHT — use np.asarray for raw numpy
-data = np.asarray(arr[mask])
+# RIGHT — just use the indexed result directly
+data = arr[uids]
 ```
 
 ### 7. Removing imports still needed by remaining code (general)
@@ -80,9 +66,9 @@ data = np.asarray(arr[mask])
 
 ## Skills That Need Updates
 
-1. **starsim-dev-sim**: Document `custom=` kwarg; add module-sharing anti-pattern
+1. **starsim-dev-sim**: Document `custom=` kwarg
 2. **starsim-dev-time**: Add array time conversion pattern (`ss.years(array).days`)
-3. **starsim-dev-indexing**: Add `np.asarray()` pattern for extracting raw arrays
-4. **starsim-dev-demographics**: Document pregnancy loss classification, NND detection, FetalHealth, congenital framework
-5. **starsim-dev-diseases**: Document generic congenital framework (`set_congenital`, `fire_congenital_outcomes`, `birth_outcome_keys`, `birth_outcomes`)
-6. **starsim-style-tests**: Add module factory pattern for multi-sim tests; note directional comparison tolerances
+3. **starsim-dev-indexing**: Note that UID-indexing returns plain numpy (no `.values`)
+4. **starsim-dev-demographics**: Reference docs for pregnancy loss classification, NND detection, FetalHealth, congenital framework
+5. **starsim-dev-diseases**: Reference docs for generic congenital framework
+6. **starsim-style-tests**: Note directional comparison tolerances

--- a/plugins/starsim/skills/starsim-dev-demographics/SKILL.md
+++ b/plugins/starsim/skills/starsim-dev-demographics/SKILL.md
@@ -325,57 +325,9 @@ sim = ss.Sim(demographics=[
 ])
 ```
 
-### 12. Pregnancy loss and neonatal death classification
+### 12. Pregnancy loss, neonatal death classification, and FetalHealth
 
-`ss.Pregnancy` classifies adverse birth outcomes automatically:
-
-- **Background pregnancy loss**: Set `p_loss` to a non-zero per-timestep probability. Early losses are naturally more common because pregnancies spend more timesteps at early gestational ages.
-- **Miscarriage vs stillbirth**: Prenatal deaths are classified by gestational age: `<loss_threshold` (default 20 weeks) = miscarriage, `>=loss_threshold` = stillbirth. Both background losses and disease-specific losses (via `request_death`) are classified.
-- **Preterm birth**: Births at `<preterm_threshold` (default 37 weeks) are flagged as preterm; `<very_preterm_threshold` (default 32 weeks) as very preterm.
-- **Neonatal death**: Deaths of agents aged 0-28 days are passively detected and classified as neonatal deaths. Any mechanism that kills a newborn (disease, congenital outcomes, background mortality) is captured.
-
-```python
-import starsim as ss
-
-pregnancy = ss.Pregnancy(
-    fertility_rate      = ss.freqperyear(30),
-    p_loss              = ss.bernoulli(p=0.005),  # 0.5% per-timestep loss probability
-    loss_threshold      = ss.weeks(20),           # Default: 20 weeks
-    preterm_threshold   = ss.weeks(37),           # Default: 37 weeks
-)
-
-sim = ss.Sim(demographics=[pregnancy, ss.Deaths()], networks='random')
-sim.run()
-
-# Results
-print(sim.results.pregnancy.miscarriages.sum())
-print(sim.results.pregnancy.stillbirths.sum())
-print(sim.results.pregnancy.nnds.sum())
-print(sim.results.pregnancy.n_preterm.sum())
-print(sim.results.pregnancy.preterm_rate)
-```
-
-States stored on newborns: `preterm`, `very_preterm`, `neonatal_death`. States stored on mothers: `n_miscarriages`, `n_stillbirths`.
-
-### 13. FetalHealth module
-
-`ss.FetalHealth` tracks gestational-age-dependent birth weight, growth restriction, and timing shifts. Pass as a custom module:
-
-```python
-sim = ss.Sim(
-    demographics=ss.Pregnancy(),
-    custom=ss.FetalHealth(),
-    networks=ss.PrenatalNet(),
-)
-```
-
-Connectors and interventions interact with fetal health via callback methods:
-- `fh.apply_timing_shift(uids, weeks)` — bring delivery forward (preterm)
-- `fh.apply_growth_restriction(uids, penalty)` — reduce birth weight
-- `fh.reverse_timing_shift(uids, fraction)` — partially undo timing shift
-- `fh.reverse_growth_restriction(uids, amount)` — partially undo growth restriction
-
-See `starsim_examples/mnch/` for complete connector and intervention examples.
+`ss.Pregnancy` supports pregnancy loss classification (miscarriage vs stillbirth by gestational age), preterm birth detection, and passive neonatal death tracking. `ss.FetalHealth` adds birth weight and growth restriction modeling as a custom module. See `starsim_examples/mnch/` for complete working examples and the [starsim pregnancy docs](https://docs.starsim.org) for API details.
 
 ## Quick reference
 

--- a/plugins/starsim/skills/starsim-dev-demographics/SKILL.md
+++ b/plugins/starsim/skills/starsim-dev-demographics/SKILL.md
@@ -325,6 +325,58 @@ sim = ss.Sim(demographics=[
 ])
 ```
 
+### 12. Pregnancy loss and neonatal death classification
+
+`ss.Pregnancy` classifies adverse birth outcomes automatically:
+
+- **Background pregnancy loss**: Set `p_loss` to a non-zero per-timestep probability. Early losses are naturally more common because pregnancies spend more timesteps at early gestational ages.
+- **Miscarriage vs stillbirth**: Prenatal deaths are classified by gestational age: `<loss_threshold` (default 20 weeks) = miscarriage, `>=loss_threshold` = stillbirth. Both background losses and disease-specific losses (via `request_death`) are classified.
+- **Preterm birth**: Births at `<preterm_threshold` (default 37 weeks) are flagged as preterm; `<very_preterm_threshold` (default 32 weeks) as very preterm.
+- **Neonatal death**: Deaths of agents aged 0-28 days are passively detected and classified as neonatal deaths. Any mechanism that kills a newborn (disease, congenital outcomes, background mortality) is captured.
+
+```python
+import starsim as ss
+
+pregnancy = ss.Pregnancy(
+    fertility_rate      = ss.freqperyear(30),
+    p_loss              = ss.bernoulli(p=0.005),  # 0.5% per-timestep loss probability
+    loss_threshold      = ss.weeks(20),           # Default: 20 weeks
+    preterm_threshold   = ss.weeks(37),           # Default: 37 weeks
+)
+
+sim = ss.Sim(demographics=[pregnancy, ss.Deaths()], networks='random')
+sim.run()
+
+# Results
+print(sim.results.pregnancy.miscarriages.sum())
+print(sim.results.pregnancy.stillbirths.sum())
+print(sim.results.pregnancy.nnds.sum())
+print(sim.results.pregnancy.n_preterm.sum())
+print(sim.results.pregnancy.preterm_rate)
+```
+
+States stored on newborns: `preterm`, `very_preterm`, `neonatal_death`. States stored on mothers: `n_miscarriages`, `n_stillbirths`.
+
+### 13. FetalHealth module
+
+`ss.FetalHealth` tracks gestational-age-dependent birth weight, growth restriction, and timing shifts. Pass as a custom module:
+
+```python
+sim = ss.Sim(
+    demographics=ss.Pregnancy(),
+    custom=ss.FetalHealth(),
+    networks=ss.PrenatalNet(),
+)
+```
+
+Connectors and interventions interact with fetal health via callback methods:
+- `fh.apply_timing_shift(uids, weeks)` — bring delivery forward (preterm)
+- `fh.apply_growth_restriction(uids, penalty)` — reduce birth weight
+- `fh.reverse_timing_shift(uids, fraction)` — partially undo timing shift
+- `fh.reverse_growth_restriction(uids, amount)` — partially undo growth restriction
+
+See `starsim_examples/mnch/` for complete connector and intervention examples.
+
 ## Quick reference
 
 | Task | Code |
@@ -342,3 +394,7 @@ sim = ss.Sim(demographics=[
 | Maternal mortality | `ss.Pregnancy(p_maternal_death=ss.bernoulli(0.001))` |
 | Breastfeeding duration | `ss.Pregnancy(dur_breastfeed=ss.lognorm_ex(mean=ss.years(0.5), std=ss.years(0.25)))` |
 | Fertility scaling factor | `ss.Pregnancy(rel_fertility=1000)` -- set to 1000 if data are per 1000 women |
+| Background pregnancy loss | `ss.Pregnancy(p_loss=ss.bernoulli(p=0.005))` |
+| Loss classification threshold | `ss.Pregnancy(loss_threshold=ss.weeks(20))` |
+| Preterm threshold | `ss.Pregnancy(preterm_threshold=ss.weeks(37))` |
+| Fetal health tracking | `ss.Sim(custom=ss.FetalHealth(), networks=ss.PrenatalNet())` |

--- a/plugins/starsim/skills/starsim-dev-diseases/SKILL.md
+++ b/plugins/starsim/skills/starsim-dev-diseases/SKILL.md
@@ -368,53 +368,7 @@ Connectors are placed in the `diseases` list (or wherever ordering makes sense f
 
 ### Pattern 9: Congenital outcomes via mother-to-child transmission
 
-The base `Infection` class provides a generic framework for congenital outcomes. Diseases opt in by defining `birth_outcome_keys` and `birth_outcomes` in pars. Transmission to unborn agents happens via `PrenatalNet`; at infection time, `set_congenital()` samples an outcome and schedules it at delivery. `fire_congenital_outcomes()` executes those events each timestep.
-
-```python
-import numpy as np
-import sciris as sc
-import starsim as ss
-
-class CongenitalDisease(ss.SIR):
-    def __init__(self, pars=None, **kwargs):
-        super().__init__()
-        self.define_pars(
-            birth_outcome_keys = ['stillborn', 'congenital', 'normal'],
-            birth_outcomes     = sc.objdict(
-                default=ss.choice(a=3, p=np.array([0.3, 0.4, 0.3])),
-            ),
-        )
-        self.update_pars(pars, **kwargs)
-        self.define_states(
-            ss.FloatArr('ti_stillborn'),
-            ss.FloatArr('ti_congenital'),
-            ss.FloatArr('ti_normal'),
-            ss.BoolArr('congenital'),
-            ss.FloatArr('cs_outcome'),
-        )
-        return
-
-    def step_state(self):
-        super().step_state()
-        self.fire_congenital_outcomes()
-        return
-
-sim = ss.Sim(
-    demographics=[ss.Pregnancy(fertility_rate=ss.freqperyear(30), burnin=True), ss.Deaths()],
-    diseases=CongenitalDisease(beta=0.2, init_prev=0.2),
-    networks=[ss.PrenatalNet(), ss.RandomNet()],
-)
-sim.run()
-```
-
-Key details:
-- **`birth_outcome_keys`**: list of outcome names. Each must have a corresponding `ti_<key>` FloatArr state and optionally a BoolArr of the same name.
-- **`birth_outcomes`**: `sc.objdict` of `ss.choice` distributions. Use `'default'` for a single distribution; use multiple keys (e.g., `'early'`, `'late'`) with `_assign_congenital_outcomes()` override for GA- or state-dependent probabilities.
-- **Death outcomes**: `'miscarriage'`, `'nnd'`, `'stillborn'` trigger `request_death`. Non-lethal outcomes set a BoolArr state.
-- **`fire_congenital_outcomes()`**: call from `step_state()` to process scheduled events.
-- **`_assign_congenital_outcomes()`**: override for diseases with state- or GA-dependent outcome probabilities.
-
-This replaces the need for each disease to implement its own congenital logic from scratch. See `starsim_examples/mnch/` for complete examples.
+The base `Infection` class provides a generic framework for congenital outcomes. Diseases opt in by defining `birth_outcome_keys` and `birth_outcomes` in pars, then calling `self.set_congenital()` at infection time. See `starsim_examples/mnch/` for complete working examples and the [starsim pregnancy docs](https://docs.starsim.org) for API details.
 
 ### Accessing results
 

--- a/plugins/starsim/skills/starsim-dev-diseases/SKILL.md
+++ b/plugins/starsim/skills/starsim-dev-diseases/SKILL.md
@@ -366,6 +366,56 @@ sim.plot('gonorrhea')
 
 Connectors are placed in the `diseases` list (or wherever ordering makes sense for the simulation step order). They are generic `ss.Module` instances, not disease subclasses. The connector's `step()` runs each timestep and can read or modify any disease state on any agent.
 
+### Pattern 9: Congenital outcomes via mother-to-child transmission
+
+The base `Infection` class provides a generic framework for congenital outcomes. Diseases opt in by defining `birth_outcome_keys` and `birth_outcomes` in pars. Transmission to unborn agents happens via `PrenatalNet`; at infection time, `set_congenital()` samples an outcome and schedules it at delivery. `fire_congenital_outcomes()` executes those events each timestep.
+
+```python
+import numpy as np
+import sciris as sc
+import starsim as ss
+
+class CongenitalDisease(ss.SIR):
+    def __init__(self, pars=None, **kwargs):
+        super().__init__()
+        self.define_pars(
+            birth_outcome_keys = ['stillborn', 'congenital', 'normal'],
+            birth_outcomes     = sc.objdict(
+                default=ss.choice(a=3, p=np.array([0.3, 0.4, 0.3])),
+            ),
+        )
+        self.update_pars(pars, **kwargs)
+        self.define_states(
+            ss.FloatArr('ti_stillborn'),
+            ss.FloatArr('ti_congenital'),
+            ss.FloatArr('ti_normal'),
+            ss.BoolArr('congenital'),
+            ss.FloatArr('cs_outcome'),
+        )
+        return
+
+    def step_state(self):
+        super().step_state()
+        self.fire_congenital_outcomes()
+        return
+
+sim = ss.Sim(
+    demographics=[ss.Pregnancy(fertility_rate=ss.freqperyear(30), burnin=True), ss.Deaths()],
+    diseases=CongenitalDisease(beta=0.2, init_prev=0.2),
+    networks=[ss.PrenatalNet(), ss.RandomNet()],
+)
+sim.run()
+```
+
+Key details:
+- **`birth_outcome_keys`**: list of outcome names. Each must have a corresponding `ti_<key>` FloatArr state and optionally a BoolArr of the same name.
+- **`birth_outcomes`**: `sc.objdict` of `ss.choice` distributions. Use `'default'` for a single distribution; use multiple keys (e.g., `'early'`, `'late'`) with `_assign_congenital_outcomes()` override for GA- or state-dependent probabilities.
+- **Death outcomes**: `'miscarriage'`, `'nnd'`, `'stillborn'` trigger `request_death`. Non-lethal outcomes set a BoolArr state.
+- **`fire_congenital_outcomes()`**: call from `step_state()` to process scheduled events.
+- **`_assign_congenital_outcomes()`**: override for diseases with state- or GA-dependent outcome probabilities.
+
+This replaces the need for each disease to implement its own congenital logic from scratch. See `starsim_examples/mnch/` for complete examples.
+
 ### Accessing results
 
 After running a simulation, disease results are available via two equivalent paths:

--- a/plugins/starsim/skills/starsim-dev-indexing/SKILL.md
+++ b/plugins/starsim/skills/starsim-dev-indexing/SKILL.md
@@ -192,6 +192,19 @@ raw_result = sim.people.age.raw[idx]     # Agent with UID 5
 
 Pick one indexing approach and use it consistently. Prefer the Starsim array methods (`.mean()`, indexing with `ss.uids()`) over direct NumPy access to `.raw` or `.values`. Code that works correctly with no deaths will silently break once deaths occur if it conflates positional and UID-based indexing.
 
+### Boolean-indexing a starsim array returns plain numpy
+
+When you boolean-index a starsim `Arr` (e.g., `arr[mask]`), the result is a plain numpy array, not a starsim `Arr`. Do not call `.values` on it — it's already raw numpy.
+
+```python
+# WRONG — arr[mask] is already numpy, .values doesn't exist
+data = fh.birth_weight[mask].values  # AttributeError
+
+# RIGHT — just use the result directly
+data = fh.birth_weight[mask]
+plt.hist(data, bins=30)
+```
+
 ### Do not forget to check if UID arrays are empty
 
 ```python

--- a/plugins/starsim/skills/starsim-dev-indexing/SKILL.md
+++ b/plugins/starsim/skills/starsim-dev-indexing/SKILL.md
@@ -206,11 +206,11 @@ is_ptb = preg.preterm[newborn_uids]
 is_lbw = fh.lbw[newborn_uids]
 
 # These already support boolean ops, sum, plotting, etc.
-n_both = int(np.sum(is_ptb & is_lbw))
+n_both = (is_ptb & is_lbw).sum()
 plt.hist(fh.birth_weight[mask], bins=30)
 ```
 
-Also note: boolean-indexing (e.g., `arr[bool_mask]`) returns a plain numpy array, so calling `.values` on it will fail.
+Also note: indexing an `Arr` with UIDs (e.g., `arr[uids]`) returns a plain numpy array, not an `Arr` — so calling `.values` on the result will fail. Just use the result directly.
 
 ### Do not forget to check if UID arrays are empty
 

--- a/plugins/starsim/skills/starsim-dev-indexing/SKILL.md
+++ b/plugins/starsim/skills/starsim-dev-indexing/SKILL.md
@@ -192,18 +192,25 @@ raw_result = sim.people.age.raw[idx]     # Agent with UID 5
 
 Pick one indexing approach and use it consistently. Prefer the Starsim array methods (`.mean()`, indexing with `ss.uids()`) over direct NumPy access to `.raw` or `.values`. Code that works correctly with no deaths will silently break once deaths occur if it conflates positional and UID-based indexing.
 
-### Boolean-indexing a starsim array returns plain numpy
+### Do not wrap starsim array indexing results in np.asarray
 
-When you boolean-index a starsim `Arr` (e.g., `arr[mask]`), the result is a plain numpy array, not a starsim `Arr`. Do not call `.values` on it — it's already raw numpy.
+When you index a starsim `Arr` with UIDs or a boolean mask, the result already works with numpy operations, boolean logic, and matplotlib. Wrapping in `np.asarray(..., dtype=bool)` or similar is unnecessary noise.
 
 ```python
-# WRONG — arr[mask] is already numpy, .values doesn't exist
-data = fh.birth_weight[mask].values  # AttributeError
+# WRONG — unnecessary wrapping
+is_ptb = np.asarray(preg.preterm[newborn_uids], dtype=bool)
+is_lbw = np.asarray(fh.lbw[newborn_uids], dtype=bool)
 
 # RIGHT — just use the result directly
-data = fh.birth_weight[mask]
-plt.hist(data, bins=30)
+is_ptb = preg.preterm[newborn_uids]
+is_lbw = fh.lbw[newborn_uids]
+
+# These already support boolean ops, sum, plotting, etc.
+n_both = int(np.sum(is_ptb & is_lbw))
+plt.hist(fh.birth_weight[mask], bins=30)
 ```
+
+Also note: boolean-indexing (e.g., `arr[bool_mask]`) returns a plain numpy array, so calling `.values` on it will fail.
 
 ### Do not forget to check if UID arrays are empty
 

--- a/plugins/starsim/skills/starsim-dev-sim/SKILL.md
+++ b/plugins/starsim/skills/starsim-dev-sim/SKILL.md
@@ -519,6 +519,32 @@ print(ppl.age.raw.mean())   # Mean age including dead -- usually not what you wa
 
 Use `.raw` only when you explicitly need dead/removed agents, such as for post-mortem analysis or validating total population accounting.
 
+**Do not reuse module instances across multiple sims.** Starsim modules (diseases, demographics, interventions, etc.) are mutated during `sim.init()` — they get bound to a specific sim, their states are initialized, distributions are seeded, etc. Passing the same module instances to multiple sims will cause failures or incorrect results.
+
+```python
+# WRONG — modules are mutated during init, can't be reused
+demog = [ss.Pregnancy(), ss.Deaths()]
+sim1 = ss.Sim(demographics=demog).run()
+sim2 = ss.Sim(demographics=demog).run()  # Fails or gives wrong results
+
+# RIGHT — use a factory function to create fresh instances
+def make_demog():
+    return [ss.Pregnancy(), ss.Deaths()]
+
+sim1 = ss.Sim(demographics=make_demog()).run()
+sim2 = ss.Sim(demographics=make_demog()).run()
+```
+
+**Use `custom=` for non-standard modules, not `modules=`.** Since v3.2.0, modules that don't fit standard types (diseases, interventions, demographics, networks, connectors, analyzers) should be passed via `custom=`. The `modules=` argument still works but auto-relocates modules to the appropriate attribute.
+
+```python
+# Preferred
+sim = ss.Sim(custom=ss.FetalHealth())
+
+# Also works but less explicit
+sim = ss.Sim(modules=ss.FetalHealth())
+```
+
 **Do not modify parameters after `sim.init()` expecting re-sampling.** Distributions are sampled during initialization. Changing a parameter value after `init()` affects only future samples (e.g., for newly born agents), not already-initialized agent states. If you need to change behavior mid-run, use an intervention or modify the state arrays directly.
 
 **Do not change Bernoulli distributions to other types.**

--- a/plugins/starsim/skills/starsim-dev-sim/SKILL.md
+++ b/plugins/starsim/skills/starsim-dev-sim/SKILL.md
@@ -519,22 +519,6 @@ print(ppl.age.raw.mean())   # Mean age including dead -- usually not what you wa
 
 Use `.raw` only when you explicitly need dead/removed agents, such as for post-mortem analysis or validating total population accounting.
 
-**Do not reuse module instances across multiple sims.** Starsim modules (diseases, demographics, interventions, etc.) are mutated during `sim.init()` — they get bound to a specific sim, their states are initialized, distributions are seeded, etc. Passing the same module instances to multiple sims will cause failures or incorrect results.
-
-```python
-# WRONG — modules are mutated during init, can't be reused
-demog = [ss.Pregnancy(), ss.Deaths()]
-sim1 = ss.Sim(demographics=demog).run()
-sim2 = ss.Sim(demographics=demog).run()  # Fails or gives wrong results
-
-# RIGHT — use a factory function to create fresh instances
-def make_demog():
-    return [ss.Pregnancy(), ss.Deaths()]
-
-sim1 = ss.Sim(demographics=make_demog()).run()
-sim2 = ss.Sim(demographics=make_demog()).run()
-```
-
 **Use `custom=` for non-standard modules, not `modules=`.** Since v3.2.0, modules that don't fit standard types (diseases, interventions, demographics, networks, connectors, analyzers) should be passed via `custom=`. The `modules=` argument still works but auto-relocates modules to the appropriate attribute.
 
 ```python

--- a/plugins/starsim/skills/starsim-dev-time/SKILL.md
+++ b/plugins/starsim/skills/starsim-dev-time/SKILL.md
@@ -269,6 +269,22 @@ print(ss.prob(0.1) * 2)  # ~ss.prob(0.19), NOT 0.2
 
 The underlying math: multiply the rate by the scalar, then convert back to probability. For `ss.prob(0.5) * 2`: rate = `-log(1 - 0.5) = 0.693`, doubled = `1.386`, new prob = `1 - exp(-1.386) = 0.75`.
 
+### Converting agent ages or durations between units
+
+Duration objects work with arrays, so always use the starsim time API instead of manual conversion factors like `* 365.25`:
+
+```python
+# WRONG — manual conversion, fragile
+age_days = sim.people.age[uids] * 365.25
+
+# RIGHT — starsim time API, works with scalars and arrays
+age_days = ss.years(sim.people.age[uids]).days
+
+# Other conversions
+ga_weeks = ss.years(duration_in_years).weeks
+months = ss.days(n_days).months
+```
+
 ## Anti-patterns
 
 ### CRITICAL: `plt.axvline(2015)` with date axes

--- a/plugins/starsim/skills/starsim-style-tests/SKILL.md
+++ b/plugins/starsim/skills/starsim-style-tests/SKILL.md
@@ -158,6 +158,24 @@ for par, (lo, hi) in par_effects.items():
     assert v0 <= v1, f'Expected higher {par} to increase prevalence'
 ```
 
+### Multi-sim tests: use factory functions for modules
+
+Starsim modules are mutated during `sim.init()`, so the same module instances cannot be shared across multiple sims. Use a factory function to create fresh instances:
+
+```python
+# WRONG — modules are mutated during init
+demog = [ss.Pregnancy(), ss.Deaths()]
+sim1 = ss.Sim(demographics=demog).run()
+sim2 = ss.Sim(demographics=demog).run()  # Fails
+
+# RIGHT — factory function creates fresh instances
+def make_demog():
+    return [ss.Pregnancy(), ss.Deaths()]
+
+sim1 = ss.Sim(demographics=make_demog()).run()
+sim2 = ss.Sim(demographics=make_demog()).run()
+```
+
 ### Agent counts
 
 Use the smallest population that produces meaningful results:

--- a/plugins/starsim/skills/starsim-style-tests/SKILL.md
+++ b/plugins/starsim/skills/starsim-style-tests/SKILL.md
@@ -158,24 +158,6 @@ for par, (lo, hi) in par_effects.items():
     assert v0 <= v1, f'Expected higher {par} to increase prevalence'
 ```
 
-### Multi-sim tests: use factory functions for modules
-
-Starsim modules are mutated during `sim.init()`, so the same module instances cannot be shared across multiple sims. Use a factory function to create fresh instances:
-
-```python
-# WRONG — modules are mutated during init
-demog = [ss.Pregnancy(), ss.Deaths()]
-sim1 = ss.Sim(demographics=demog).run()
-sim2 = ss.Sim(demographics=demog).run()  # Fails
-
-# RIGHT — factory function creates fresh instances
-def make_demog():
-    return [ss.Pregnancy(), ss.Deaths()]
-
-sim1 = ss.Sim(demographics=make_demog()).run()
-sim2 = ss.Sim(demographics=make_demog()).run()
-```
-
 ### Agent counts
 
 Use the smallest population that produces meaningful results:


### PR DESCRIPTION
## Summary
- **starsim-dev-sim**: Add module-sharing anti-pattern and `custom=` kwarg documentation
- **starsim-dev-time**: Add array time conversion pattern (`ss.years(arr).days`)
- **starsim-dev-indexing**: Add gotcha about boolean-indexed arrays returning plain numpy
- **starsim-dev-demographics**: Document pregnancy loss classification, NND detection, FetalHealth
- **starsim-dev-diseases**: Document generic congenital outcome framework
- **starsim-style-tests**: Add module factory pattern for multi-sim tests
- **internal**: Add session feedback document with all lessons learned

## Test plan
- [ ] Review skill content for accuracy
- [ ] Verify examples are syntactically correct